### PR TITLE
Change to add packages to repo and update existing link

### DIFF
--- a/README.md
+++ b/README.md
@@ -686,4 +686,4 @@ add packages to the list.
 
 ### Python - Editor Extensions
 
-- [pyshiny-vscode](https://marketplace.visualstudio.com/items?itemName=rstudio.pyshiny) - VS Code extension to help launch Shiny for Python applications.
+- [pyshiny-vscode](https://marketplace.visualstudio.com/items?itemName=posit.shiny-python) - VS Code extension to help launch Shiny for Python applications.

--- a/README.md
+++ b/README.md
@@ -646,10 +646,10 @@ add packages to the list.
 
 ### Dependency Resolution
 
+- [renv](https://github.com/rstudio/renv) - Create isolated, portable, and reproducible environments for R projects.
 - [packrat](https://github.com/rstudio/packrat) - Parse R package dependencies of Shiny apps with `packrat::appDependencies`.
 - [sysreqsdb](https://github.com/r-hub/sysreqsdb) - SystemRequirements mappings for R packages.
 - [shinyapps-package-dependencies](https://github.com/rstudio/shinyapps-package-dependencies) - A collection of bash scripts that install system dependencies for R packages.
-- [renv](https://github.com/rstudio/renv) - Create isolated, portable and reproducible environments for R projects.
 
 ### Editor Extensions
 

--- a/README.md
+++ b/README.md
@@ -610,6 +610,7 @@ add packages to the list.
 - [tidymodules](https://github.com/Novartis/tidymodules) - An object-oriented approach to Shiny modules.
 - [supreme](https://github.com/strboul/supreme) - Structure Shiny applications developed with modules.
 - [packer](https://github.com/JohnCoene/packer) - An opinionated framework for using JavaScript with R.
+- [box](https://github.com/klmr/box) - Organize code into hierarchical, composable, reusable modules, to use across projects.
 
 ### Debugging
 
@@ -648,6 +649,7 @@ add packages to the list.
 - [packrat](https://github.com/rstudio/packrat) - Parse R package dependencies of Shiny apps with `packrat::appDependencies`.
 - [sysreqsdb](https://github.com/r-hub/sysreqsdb) - SystemRequirements mappings for R packages.
 - [shinyapps-package-dependencies](https://github.com/rstudio/shinyapps-package-dependencies) - A collection of bash scripts that install system dependencies for R packages.
+- [renv](https://github.com/rstudio/renv) - Create isolated, portable and reproducible environments for R projects.
 
 ### Editor Extensions
 


### PR DESCRIPTION
Hi Nan!

I would like to suggest adding some useful packages which help to improve sharing R projects and writing modular R code.

1. [renv](https://github.com/rstudio/renv)
The renv package by RStudio would be a great addition given that it is the successor of the packrat package.

2. [box](https://github.com/klmr/box)
This package helps in writing modular and reusable R code.

3. In this [link](https://github.com/nanxstats/awesome-shiny-extensions#python---deploy), the `pyshiny-vscode` link is deprecated and moved to `https://marketplace.visualstudio.com/items?itemName=posit.shiny-python`
I have included this change in this PR.

Thank you for maintaining this repo!