### PR TITLE
Allow HTTP 429 in awesome_bot link checker

### DIFF
--- a/.github/workflows/awesome-bot.yml
+++ b/.github/workflows/awesome-bot.yml
@@ -29,4 +29,4 @@ jobs:
       - name: "install awesome-bot"
         run: gem install awesome_bot
       - name: "linting: README.md"
-        run: awesome_bot README.md --allow 303
+        run: awesome_bot README.md --allow 303,429


### PR DESCRIPTION
As we exceed 500 GitHub repo links in the list, it's becoming much more common to see HTTP 429 (too many requests) when checking GitHub repo URL validity via the awesome bot link checker. This PR adds this HTTP code to the allow list so the GitHub Actions workflow won't result in an error all the time.