### PR TITLE
Add 6 Python packages to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1024,6 +1024,7 @@ add packages to the list.
 
 ### Python - Theming
 
+- [brand-yml](https://github.com/posit-dev/brand-yml) - Unified branding with `_brand.yml` files.
 - [py-shinyswatch](https://github.com/posit-dev/py-shinyswatch) - Bootswatch themes for py-shiny.
 
 ### Python - UI Components
@@ -1031,14 +1032,19 @@ add packages to the list.
 - [py-htmltools](https://github.com/posit-dev/py-htmltools) - Tools for creating, manipulating, and writing HTML from Python.
 - [py-faicons](https://github.com/posit-dev/py-faicons) - An interface to Font Awesome for use in Shiny for Python.
 - [py-shinywidgets](https://github.com/posit-dev/py-shinywidgets) - Render ipywidgets inside a Shiny app.
+- [py-shiny-validate](https://github.com/posit-dev/py-shiny-validate) - Input validation for Shiny for Python applications.
+- [shinymedia](https://github.com/posit-dev/shinymedia) - UI controls for recording video clips and playing audio media.
 - [py_shiny_semantic](https://github.com/Appsilon/py_shiny_semantic) - Create rich web applications in PyShiny using styles and components from Fomantic UI.
 
 ### Python - Chat
 
 - [shinychat](https://github.com/posit-dev/shinychat/tree/main/pkg-py) - Chat UI component for Shiny for Python.
+- [shinyrealtime](https://github.com/posit-dev/shinyrealtime) - Integrate OpenAI's Realtime API.
 
 ### Python - Table
 
+- [great-tables](https://github.com/posit-dev/great-tables) - Create styled display tables in Python.
+- [gt-extras](https://github.com/posit-dev/gt-extras) - Additional helper functions for enhancing great-tables tables.
 - [itables](https://github.com/mwouts/itables) - Display Pandas and Polars data frames as interactive DataTables that you can sort, paginate, scroll, and filter.
 - [reactable-py](https://github.com/machow/reactable-py) - Interactive data tables for Python, port of the R package reactable.
 

--- a/updater/prompts-py.md
+++ b/updater/prompts-py.md
@@ -1,0 +1,67 @@
+Act as a senior research software engineer and open source software curator with 10 years of experience working with Shiny for R, and recently, Shiny for Python.
+
+Your task is to update this awesome list "awesome-shiny-extensions" in @README.md by adding Python packages not included by the list yet, under the "Shiny for Python" sections.
+
+To get the potential list of packages to consider, you can use the GitHub CLI command `gh repo list` to get a list of repositories owned by the `posit-dev` organization on GitHub. The `gh repo list` usage documentation is attached below. A few quick pointers to narrow down the list quickly:
+
+- Exclude packages that are already included in the awesome list.
+- Exclude packages that are apparently not Shiny for Python extensions judging by the repo name and description.
+- Add packages that are apparently Shiny for Python extensions.
+- For the remaining packages, if further look is needed, use `gh repo clone` to clone the repo and inspect the code.
+
+After confirming a package is a Shiny for Python extension, add it to the awesome list in @README.md in the appropriate Python section with a brief description based on the package description. Follow the formatting style of the existing entries in the awesome list. If you find a package that does not fit into any existing section, create a new section for it and add it there. Do not create new sections in the awesome list unless absolutely necessary. Fan out subagents to handle the tasks of checking the packages.
+
+`gh repo list` documentation:
+
+````markdown
+```
+gh repo list [<owner>] [flags]
+```
+
+List repositories owned by a user or organization.
+
+Note that the list will only include repositories owned by the provided argument, and the `--fork` or `--source` flags will not traverse ownership boundaries. For example, when listing the forks in an organization, the output would not include those owned by individual users.
+
+## Options
+
+--archived
+Show only archived repositories
+
+--fork
+Show only forks
+
+-q, --jq <expression>
+Filter JSON output using a jq expression
+
+--json <fields>
+Output JSON with the specified fields
+
+-l, --language <string>
+Filter by primary coding language
+
+-L, --limit <int> (default 30)
+Maximum number of repositories to list
+
+--no-archived
+Omit archived repositories
+
+--source
+Show only non-forks
+
+-t, --template <string>
+Format JSON output using a Go template; see "gh help formatting"
+
+--topic <strings>
+Filter by topic
+
+--visibility <string>
+Filter by repository visibility: {public|private|internal}
+
+## ALIASES
+
+gh repo ls
+
+## JSON Fields
+
+archivedAt, assignableUsers, codeOfConduct, contactLinks, createdAt, defaultBranchRef, deleteBranchOnMerge, description, diskUsage, forkCount, fundingLinks, hasDiscussionsEnabled, hasIssuesEnabled, hasProjectsEnabled, hasWikiEnabled, homepageUrl, id, isArchived, isBlankIssuesEnabled, isEmpty, isFork, isInOrganization, isMirror, isPrivate, isSecurityPolicyEnabled, isTemplate, isUserConfigurationRepository, issueTemplates, issues, labels, languages, latestRelease, licenseInfo, mentionableUsers, mergeCommitAllowed, milestones, mirrorUrl, name, nameWithOwner, openGraphImageUrl, owner, parent, primaryLanguage, projects, projectsV2, pullRequestTemplates, pullRequests, pushedAt, rebaseMergeAllowed, repositoryTopics, securityPolicyUrl, squashMergeAllowed, sshUrl, stargazerCount, templateRepository, updatedAt, url, usesCustomOpenGraphImage, viewerCanAdminister, viewerDefaultCommitEmail, viewerDefaultMergeMethod, viewerHasStarred, viewerPermission, viewerPossibleCommitEmails, viewerSubscription, visibility, watchers
+````


### PR DESCRIPTION
This PR adds 6 Python packages to the Shiny for Python section of the list.

Also adds a reusable prompt to pull relevant information from GitHub via `gh` CLI.